### PR TITLE
fix: generate seed by Math.random()

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -248,7 +248,7 @@ export function apply(ctx: Context, config: Config) {
 
       const model = modelMap[options.model]
       const orient = orientMap[options.orient]
-      const seed = options.seed || Math.round(new Date().getTime() / 1000)
+      const seed = options.seed || Math.floor(Math.random() * Math.pow(2, 32)) // seed can be up to 2^32
       session.send(session.text('.waiting'))
 
       const parameters: Dict = {


### PR DESCRIPTION
as it returns a dependent range of random numbers,
and novel ai supports seed up to 2^32.