### PR TITLE
feat: support emojis

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "vitepress": "1.0.0-alpha.20"
   },
   "dependencies": {
+    "emoji-regex": "^10.2.1",
     "image-size": "^1.0.2",
     "libsodium-wrappers": "^0.7.10"
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,5 @@
 import { Dict, Schema, Time } from 'koishi'
-import { Size } from './utils'
+import { isEmoji, Size } from './utils'
 
 export const modelMap = {
   safe: 'safe-diffusion',
@@ -230,7 +230,7 @@ export function parseInput(input: string, config: Config, forbidden: Forbidden[]
     .replace(backslash, '\\')
     .replace(/_/g, ' ')
 
-  if (/[^\s\w"'“”‘’.,:|\\()\[\]{}-]/.test(input)) {
+  if ([...input.matchAll(/[^\s\w"'“”‘’.,:|\\()\[\]{}-]/g)].findIndex(match => !isEmoji(match[0])) !== -1) {
     return ['.invalid-input']
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,6 +5,7 @@ import {
 } from 'libsodium-wrappers'
 import imageSize from 'image-size'
 import { Subscription } from './types'
+import emojiRegex from 'emoji-regex'
 
 export function project(object: {}, mapping: {}) {
   const result = {}
@@ -190,4 +191,8 @@ export function stripDataPrefix(base64: string) {
   // workaround for different gradio versions
   // https://github.com/koishijs/novelai-bot/issues/90
   return base64.replace(/^data:image\/[\w-]+;base64,/, '')
+}
+
+export function isEmoji(str: string) {
+  return emojiRegex().test(str)
 }


### PR DESCRIPTION
used a lib for emoji identification as it's too large to be hard coded (~7kb).

the lib probably can be replaced with [this](https://github.com/tc39/proposal-regexp-v-flag) soon

(#97)