### PR TITLE
fix: sd-webui reporting 500 error using img2img

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -103,7 +103,7 @@ export function apply(ctx: Context, config: Config) {
     .action(async ({ session, options }, input) => {
       if (!input?.trim()) return session.execute('help novelai')
 
-      let imgUrl: string
+      let imgUrl: string, image: ImageData
       if (!restricted(session)) {
         input = segment.transform(input, {
           image(attrs) {
@@ -152,8 +152,6 @@ export function apply(ctx: Context, config: Config) {
         ucPreset: 2,
         qualityToggle: false,
       }
-      
-      let image: ImageData
 
       if (imgUrl) {
         try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -166,7 +166,7 @@ export function apply(ctx: Context, config: Config) {
         }
 
         Object.assign(parameters, {
-          image: image[1],
+          image,
           scale: options.scale ?? 11,
           steps: options.steps ?? 50,
         })
@@ -234,13 +234,14 @@ export function apply(ctx: Context, config: Config) {
       const data = (() => {
         if (config.type !== 'sd-webui') {
           parameters.sampler = sampler.sd2nai(options.sampler)
+          parameters.image = parameters.image[1] // NovelAI / NAIFU accepts bare base64 encoded image
           if (config.type === 'naifu') return parameters
           return { model, input: prompt, parameters: omit(parameters, ['prompt']) }
         }
 
         return {
           sampler_index: sampler.sd[options.sampler],
-          init_images: parameters.image && [parameters.image],
+          init_images: parameters.image && [parameters.image[2]], // sd-webui accepts data URLs with base64 encoded image
           ...project(parameters, {
             prompt: 'prompt',
             batch_size: 'n_samples',

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { Context, Dict, Logger, omit, Quester, segment, Session, trimSlash } from 'koishi'
 import { Config, modelMap, models, orientMap, parseForbidden, parseInput, sampler } from './config'
-import { StableDiffusionWebUI } from './types'
+import { ImageData, StableDiffusionWebUI } from './types'
 import { closestMultiple, download, getImageSize, login, NetworkError, project, resizeInput, Size, stripDataPrefix } from './utils'
 import {} from '@koishijs/plugin-help'
 
@@ -152,9 +152,10 @@ export function apply(ctx: Context, config: Config) {
         ucPreset: 2,
         qualityToggle: false,
       }
+      
+      let image: ImageData
 
       if (imgUrl) {
-        let image: [buffer: ArrayBuffer, base64: string, dataUrl: string]
         try {
           image = await download(ctx, imgUrl)
         } catch (err) {
@@ -166,12 +167,11 @@ export function apply(ctx: Context, config: Config) {
         }
 
         Object.assign(parameters, {
-          image,
           scale: options.scale ?? 11,
           steps: options.steps ?? 50,
         })
         if (options.enhance) {
-          const size = getImageSize(image[0])
+          const size = getImageSize(image.buffer)
           if (size.width + size.height !== 1280) {
             return session.text('.invalid-size')
           }
@@ -182,7 +182,7 @@ export function apply(ctx: Context, config: Config) {
             strength: options.strength ?? 0.2,
           })
         } else {
-          options.resolution ||= resizeInput(getImageSize(image[0]))
+          options.resolution ||= resizeInput(getImageSize(image.buffer))
           Object.assign(parameters, {
             height: options.resolution.height,
             width: options.resolution.width,
@@ -223,7 +223,7 @@ export function apply(ctx: Context, config: Config) {
       const path = (() => {
         switch (config.type) {
           case 'sd-webui':
-            return parameters.image ? '/sdapi/v1/img2img' : '/sdapi/v1/txt2img'
+            return image ? '/sdapi/v1/img2img' : '/sdapi/v1/txt2img'
           case 'naifu':
             return '/generate-stream'
           default:
@@ -234,14 +234,14 @@ export function apply(ctx: Context, config: Config) {
       const data = (() => {
         if (config.type !== 'sd-webui') {
           parameters.sampler = sampler.sd2nai(options.sampler)
-          parameters.image = parameters.image[1] // NovelAI / NAIFU accepts bare base64 encoded image
+          parameters.image = image.base64 // NovelAI / NAIFU accepts bare base64 encoded image
           if (config.type === 'naifu') return parameters
           return { model, input: prompt, parameters: omit(parameters, ['prompt']) }
         }
 
         return {
           sampler_index: sampler.sd[options.sampler],
-          init_images: parameters.image && [parameters.image[2]], // sd-webui accepts data URLs with base64 encoded image
+          init_images: image && [image.dataUrl], // sd-webui accepts data URLs with base64 encoded image
           ...project(parameters, {
             prompt: 'prompt',
             batch_size: 'n_samples',

--- a/src/index.ts
+++ b/src/index.ts
@@ -154,7 +154,7 @@ export function apply(ctx: Context, config: Config) {
       }
 
       if (imgUrl) {
-        let image: [buffer: ArrayBuffer, base64: string, dataUrl: string]
+        let image: [ArrayBuffer, string, string]
         try {
           image = await download(ctx, imgUrl)
         } catch (err) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -154,7 +154,7 @@ export function apply(ctx: Context, config: Config) {
       }
 
       if (imgUrl) {
-        let image: [ArrayBuffer, string]
+        let image: [buffer: ArrayBuffer, base64: string, dataUrl: string]
         try {
           image = await download(ctx, imgUrl)
         } catch (err) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -154,7 +154,7 @@ export function apply(ctx: Context, config: Config) {
       }
 
       if (imgUrl) {
-        let image: [ArrayBuffer, string, string]
+        let image: [buffer: ArrayBuffer, base64: string, dataUrl: string]
         try {
           image = await download(ctx, imgUrl)
         } catch (err) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,6 +38,12 @@ export interface Subscription {
   trainingStepsLeft: TrainingStepsLeft
 }
 
+export interface ImageData {
+  buffer: ArrayBuffer
+  base64: string
+  dataUrl: string
+}
+
 export namespace StableDiffusionWebUI {
   export interface Request {
     prompt: string

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,7 +4,7 @@ import {
   crypto_pwhash_ALG_ARGON2ID13, crypto_pwhash_SALTBYTES, ready,
 } from 'libsodium-wrappers'
 import imageSize from 'image-size'
-import { Subscription } from './types'
+import { ImageData, Subscription } from './types'
 
 export function project(object: {}, mapping: {}) {
   const result = {}
@@ -47,7 +47,7 @@ const MAX_OUTPUT_SIZE = 1048576
 const MAX_CONTENT_SIZE = 10485760
 const ALLOWED_TYPES = ['image/jpeg', 'image/png']
 
-export async function download(ctx: Context, url: string, headers = {}): Promise<[buffer: ArrayBuffer, base64: string, dataUrl: string]> {
+export async function download(ctx: Context, url: string, headers = {}): Promise<ImageData> {
   if (url.startsWith('data:')) {
     const [, type, base64] = url.match(/^data:(image\/\w+);base64,(.*)$/)
     if (!ALLOWED_TYPES.includes(type)) {
@@ -58,7 +58,7 @@ export async function download(ctx: Context, url: string, headers = {}): Promise
     for (let i = 0; i < binary.length; i++) {
       result[i] = binary.charCodeAt(i)
     }
-    return [result, base64, url]
+    return { buffer: result, base64, dataUrl: url }
   } else {
     const head = await ctx.http.head(url, { headers })
     if (+head['content-length'] > MAX_CONTENT_SIZE) {
@@ -70,7 +70,7 @@ export async function download(ctx: Context, url: string, headers = {}): Promise
     }
     const buffer = await ctx.http.get(url, { responseType: 'arraybuffer', headers })
     const base64 = arrayBufferToBase64(buffer)
-    return [buffer, base64, `data:${mimetype};base64,${base64}`]
+    return { buffer, base64, dataUrl: `data:${mimetype};base64,${base64}` }
   }
 }
 


### PR DESCRIPTION
The Stable Diffusion Web UI changed their API recently, the prototype img2img API accepts data URLs and bare base64 encoded image both. But in https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/3511 they changed the function so that only data URLs accepted now (and didn't catch the exception).

This patch is trying to add an experimental data URL prefix for the base64 string, in order to match the changes on Stable Diffusion Web UI side.

Fixes #104

------

稳定的扩散网页用户界面最近改变了他们的API，原型img2img API接受数据URL和纯粹base64编码的图像。但是在 https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/3511 他们改变了函数，使得现在仅有数据URL被接受（而且没有捕获异常）。

这个补丁试图为base64字符串添加一个试验性的数据URL前缀，以匹配稳定的扩散网页用户界面方面的改动。

修复 #104