### PR TITLE
fix: add back hires fix support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -270,6 +270,7 @@ export function apply(ctx: Context, config: Config) {
             return {
               sampler_index: sampler.sd[options.sampler],
               init_images: image && [image.dataUrl], // sd-webui accepts data URLs with base64 encoded image
+              enable_hr: options.hiresFix ?? config.hiresFix ?? false,
               ...project(parameters, {
                 prompt: 'prompt',
                 batch_size: 'n_samples',


### PR DESCRIPTION
This line of code was originally added by #133 but mistakenly dropped out in #145 , we add it back to fix this.