### PR TITLE
feat: support angle brackets, close #161

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -335,7 +335,7 @@ export function parseInput(input: string, config: Config, forbidden: Forbidden[]
     .replace(backslash, '\\')
     .replace(/_/g, ' ')
 
-  if (config.latinOnly && /[^\s\w"'“”‘’.,:|\\()\[\]{}-]/.test(input)) {
+  if (config.latinOnly && /[^\s\w"'“”‘’.,:|\\()\[\]{}<>-]/.test(input)) {
     return ['.latin-only']
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -423,9 +423,9 @@ export function apply(ctx: Context, config: Config) {
             }
           }
           result.children.push(h('message', attrs, lines.join('\n')))
-          result.children.push(h('message', attrs, `prompt = ${prompt}`))
+          result.children.push(h('message', attrs, `prompt = ${h.escape(prompt)}`))
           if (options.output === 'verbose') {
-            result.children.push(h('message', attrs, `undesired = ${uc}`))
+            result.children.push(h('message', attrs, `undesired = ${h.escape(uc)}`))
           }
           result.children.push(h('message', attrs, h.image(dataUrl)))
           return result

--- a/src/locales/zh-CN.yml
+++ b/src/locales/zh-CN.yml
@@ -26,6 +26,8 @@ commands:
       exceed-max-iteration: 超过最大绘制次数。
       expect-prompt: 请输入标签。
       expect-image: 请输入图片。
+      too-many-images: 过多的图片。
+      invalid-content: 输入中含有无效内容。
       latin-only: 只接受英文输入。
       too-many-words: 输入的单词数量过多。
       forbidden-word: 输入含有违禁词。


### PR DESCRIPTION
此 PR 等待上游特性更新：`el.toString(true)` 应当返回 unescape 后的文本 (将在 4.11.6 实装)。

Note: 我可以直接在此 PR 中加入 unescape，但这会导致上游更新后实际上 unescape 两次，在极端情况下会有不同的行为。