### PR TITLE
fix: response type for naifu

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -413,7 +413,7 @@ export function apply(ctx: Context, config: Config) {
             method: 'POST',
             timeout: config.requestTimeout,
             // Since novelai's latest interface returns an application/x-zip-compressed, a responseType must be passed in
-            responseType: ['login', 'token'].includes(config.type) ? 'arraybuffer' : 'json',
+            responseType: config.type === 'naifu' ? 'text' : ['login', 'token'].includes(config.type) ? 'arraybuffer' : 'json',
             headers: {
               ...config.headers,
               ...getHeaders(),


### PR DESCRIPTION
修复一个关于naifu的bug
- 将naifu的回复类型设定为text类型
  - 在使用naifu时，response是text/event-stream类型，但是目前的代码会期待一个json的返回值从而造成以下错误
  - ![@_`36NI9EFAB(K81)JDI$)S](https://github.com/koishijs/novelai-bot/assets/34560903/9c21f43a-2b0a-4e62-a008-d858802adc5f)
