### PR TITLE
fix: configs for nai-v3 model not showing

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -370,7 +370,7 @@ export const Config = Schema.intersect([
       }),
       Schema.union([
         Schema.object({
-          model: Schema.const('nai-v3').required(),
+          model: Schema.const('nai-v3'),
           sampler: sampler.createSchema(sampler.nai3),
           smea: Schema.boolean().description('默认启用 SMEA。'),
           smeaDyn: Schema.boolean().description('默认启用 SMEA 采样器的 DYN 变体。'),


### PR DESCRIPTION
It looks like the `Schema` of `model` should not be `required()` in my understanding, after removing it, the config would show as expected.

![image](https://github.com/user-attachments/assets/0a526f82-0ee7-4d01-ba89-d33b96df3d66)

fix #252