### PR TITLE
Feat: add sd-webui-dtg extension support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { Computed, Context, Dict, h, Logger, omit, Quester, Session, SessionErro
 import { Config, modelMap, models, orientMap, parseInput, sampler, upscalers, scheduler } from './config'
 import { ImageData, StableDiffusionWebUI } from './types'
 import { closestMultiple, download, forceDataPrefix, getImageSize, login, NetworkError, project, resizeInput, Size } from './utils'
+import { genExtensionsArgs } from './webuiExtension'
 import { } from '@koishijs/translator'
 import { } from '@koishijs/plugin-help'
 import AdmZip from 'adm-zip'
@@ -118,10 +119,10 @@ export function apply(ctx: Context, config: Config) {
       type: ['token', 'login'].includes(config.type)
         ? scheduler.nai
         : config.type === 'sd-webui'
-        ? scheduler.sd
-        : config.type === 'stable-horde'
-        ? scheduler.horde
-        : [],
+          ? scheduler.sd
+          : config.type === 'stable-horde'
+            ? scheduler.horde
+            : [],
     })
     .option('decrisper', '-D', { hidden: thirdParty })
     .option('undesired', '-u <undesired>')
@@ -360,6 +361,7 @@ export function apply(ctx: Context, config: Config) {
             return { model, input: prompt, parameters: omit(parameters, ['prompt']) }
           }
           case 'sd-webui': {
+            const extensionsArgs = genExtensionsArgs(session, config)
             return {
               sampler_index: sampler.sd[options.sampler],
               scheduler: options.scheduler,
@@ -368,6 +370,7 @@ export function apply(ctx: Context, config: Config) {
               enable_hr: options.hiresFix ?? config.hiresFix ?? false,
               hr_second_pass_steps: options.hiresFixSteps ?? 0,
               hr_upscaler: config.hiresFixUpscaler ?? 'None',
+              alwayson_scripts: extensionsArgs,
               ...project(parameters, {
                 prompt: 'prompt',
                 batch_size: 'n_samples',

--- a/src/webuiExtension.ts
+++ b/src/webuiExtension.ts
@@ -1,0 +1,53 @@
+import { Session } from "koishi"
+import { Config, DanTagGenConfig } from "./config"
+
+type WebUiExtensionArgs = Array<boolean | number | string | object | null>
+
+interface ExtensionGenRes {
+    name: string,
+    args: WebUiExtensionArgs
+}
+
+interface WebUiExtensionParams {
+    [key: string]: { args: WebUiExtensionArgs }
+}
+
+function danTagGen(session: Session, config: Config): ExtensionGenRes | false {
+    if (!config.danTagGen || !config.danTagGen.enabled) return false
+
+    const danTagGenConfig = config.danTagGen as DanTagGenConfig
+    return {
+        name: 'DanTagGen',
+        args: [
+            true,  // enable
+            danTagGenConfig.upsamplingTiming === 'After'
+                ? 'After applying other prompt processings'
+                : 'Before applying other prompt processings',
+            danTagGenConfig.upsamplingTagsSeed,
+            danTagGenConfig.totalTagLength,
+            danTagGenConfig.banTags,
+            danTagGenConfig.promptFormat,
+            danTagGenConfig.temperature,
+            danTagGenConfig.topP,
+            danTagGenConfig.topK,
+            danTagGenConfig.model,
+            danTagGenConfig.useCpu,
+            danTagGenConfig.noFormatting,
+        ]
+    }
+}
+
+const webUiExtensions: Array<(session: Session, config: Config) => ExtensionGenRes | false> = [danTagGen]
+
+export function genExtensionsArgs(session: Session, config: Config): WebUiExtensionParams {
+    if (!config.danTagGen) return {}
+    const args: WebUiExtensionParams = {}
+    for (const extension of webUiExtensions) {
+        const _args = extension(session, config)
+        if (_args) {
+            args[_args.name] = { args: _args.args }
+        }
+    }
+    return args
+}
+


### PR DESCRIPTION
Known issue: the order of the extension switch and the extension options are reversed
![image](https://github.com/user-attachments/assets/a6951829-81c0-4068-8213-60021370542a)

Check the code below, this won't work if the order is correct, might be a schemastery schema parser problem?
https://github.com/Ninzore/koishi-plugin-novelai/blob/bd8b711de523a0171f74d87f5a549af42b606a59/src/config.ts#L490